### PR TITLE
Added support for NGR country code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "amountinwords",
+  "name": "amount-in-words",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "build": "tsc",
     "test": "npx jest",
-    "prepare" : "npm run build",
-    "prepublishOnly" : "npm test",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm test",
     "version": "npm run format && git add -A src",
     "postversion": "git push && git push --tags"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export enum CountryCodes {
   IND = "IND",
   USA = "USA",
   GBR = "GBR",
+  NGR = "NGR",
 }
 
 export class AmountToWords {
@@ -49,22 +50,33 @@ export class AmountToWords {
       "Trillion ",
     ],
     inNumSys: ["", "Hundred ", "Thousand ", "Lakh ", "Crore "],
+
   };
+
+  /**
+   * Ifelere: Naira does not not have an 's' for plural therefore this map is adjusted to have currencies declare plural form
+   */
   private curCodes: { [countryCode: string]: string[] } = {
-    IND: ["Rupee", "Paisa", "Paise", "₹", "inNumSys"],
-    USA: ["Dollar", "Cent", "Cents", "$", "usNumSys"],
-    GBR: ["Pound", "Pence", "Pence", "£", "usNumSys"],
+    IND: ["Rupee", "Paisa", "Paise", "₹", "inNumSys", "Rupees"],
+    USA: ["Dollar", "Cent", "Cents", "$", "usNumSys", "Dollars"],
+    GBR: ["Pound", "Pence", "Pence", "£", "usNumSys", "Pounds"],
+    NGR: ["Naira", "Kobo", "Kobo", "₦", "usNumSys", "Naira"]
   };
 
   private getCurrencyWhole = (
     countryCode: string = "IND",
     amount: number = 0
   ) => {
+    // Ifelere: If the amount is more than one use index 5 of curCodes map
+    const index = amount > 1 ? 5 : 0;
+
     const cur = this.curCodes[countryCode]
-      ? this.curCodes[countryCode][0]
-      : this.curCodes["IND"][0];
-    if (amount > 1) return cur + "s";
-    else return cur;
+      ? this.curCodes[countryCode][index]
+      : this.curCodes["IND"][index];
+
+    // if (amount > 1) return cur + "s";
+    // else return cur;
+    return cur;
   };
 
   private getCurrencyChange = (countryCode: string, amount: number = 0) => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -42,3 +42,13 @@ test('pence-1', () => {
 test('pence-55', () => {
     expect(atw.convertInWord('001.55', CountryCodes.GBR)).toEqual('One Pound And Fifty Five Pence');
 });
+
+test('supports ngr country code', () => {
+    expect(atw.convertInWord(1000, CountryCodes.NGR)).toEqual('One Thousand Naira');
+    expect(atw.convertInWord('001.55', CountryCodes.NGR)).toEqual('One Naira And Fifty Five Kobo');
+    expect(atw.convertInWord('0.01', CountryCodes.NGR)).toEqual('Zero Naira And One Kobo');
+    expect(atw.convertInWord('001.87', CountryCodes.NGR)).toEqual('One Naira And Eighty Seven Kobo');
+    expect(atw.convertInWord('632,362,999,101,001', CountryCodes.NGR)).toEqual('Six Hundred Thirty Two Trillion Three Hundred Sixty Two Billion Nine Hundred Ninety Nine Million One Hundred One Thousand One Naira');
+    expect(atw.convertInWord(554272561010, CountryCodes.NGR)).toEqual('Five Hundred Fifty Four Billion Two Hundred Seventy Two Million Five Hundred Sixty One Thousand Ten Naira');
+
+})


### PR DESCRIPTION
Included 'NGR' country code in curCodes map with us number system
Added an extra element for curCodes to declare plural form of country currency
Modify #getCurrentWhole method to depend on pluralization in curCodes map
Added tests to be sure 'NGR' country code utilization works with the system as expected