### PR TITLE
Added support for inserting 'and' in whole part format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,17 @@ export enum CountryCodes {
   GBR = "GBR",
 }
 
+export enum FormatImplementation {
+  DEFAULT = "default",
+  USE_AND_IN_NO_CHANGE_US_SYSTEM = "USE_AND_IN_NO_CHANGE_US_SYSTEM"
+}
+
+
+export interface ConvertOptions {
+  implementation?: FormatImplementation
+}
+
+
 export class AmountToWords {
   private first = [
     "",
@@ -90,8 +101,10 @@ export class AmountToWords {
       : this.curCodes["IND"][4];
   };
 
-  public convertInWord = (num: any, countryCode: string = "IND") => {
+  public convertInWord = (num: any, countryCode: string = "IND", options?: ConvertOptions) => {
     // console.log(num);
+    options = options || {implementation: FormatImplementation.DEFAULT};
+
     const numSys = this.numSys[this.getNumSys(countryCode)];
     const nStr = num.toString().split(".");
     // Remove any other characters than numbers
@@ -100,7 +113,7 @@ export class AmountToWords {
     const wholeStrPart =
       this.getNumSys(countryCode) === "inNumSys"
         ? this.convert(wholeStr, numSys).trim()
-        : this.convertInUS(wholeStr, numSys).trim();
+        : this.convertInUS(wholeStr, numSys, options.implementation || FormatImplementation.DEFAULT, decimalStr).trim();
     const decimalPart = this.convert(decimalStr, numSys).trim();
     let valueInStr =
       wholeStrPart.length > 0
@@ -131,15 +144,20 @@ export class AmountToWords {
     return finalStr.join("");
   };
 
-  private convertInUS = (num: number | string, numSys: string[]) => {
+  private convertInUS = (num: number | string, numSys: string[], implementation: FormatImplementation, trailingFigure: number = 0) => {
     const numStr = num.toString().split("");
     const finalStr = [];
     while (numStr.length > 0) {
       // console.log(numSys.length);
       for (let i = 0, l = numSys.length * 2 - 1; i < l; ++i) {
         // console.log(numStr, i, (i/2)+1);
-        if (i === 0)
-          finalStr.unshift(this.getUnits(numStr.splice(-2), numSys, 0));
+        if (i === 0) {
+          let part = this.getUnits(numStr.splice(-2), numSys, 0);
+          if (part && trailingFigure < 1 && implementation === FormatImplementation.USE_AND_IN_NO_CHANGE_US_SYSTEM) {
+            part = `And ${part}`;
+          }
+          finalStr.unshift(part);
+        }
         else if (i % 2 === 1)
           finalStr.unshift(this.getUnits(numStr.splice(-1), numSys, 1));
         else {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,4 +1,4 @@
-import { AmountToWords, CountryCodes } from '../src/index';
+import { AmountToWords, CountryCodes, FormatImplementation } from '../src/index';
 
 const atw = new AmountToWords();
 
@@ -21,17 +21,27 @@ test('paisa-paise', () => {
 });
 
 // International Numbering System
+
+test('intl. basic', () => {
+    expect(atw.convertInWord(123, CountryCodes.USA, {implementation: FormatImplementation.USE_AND_IN_NO_CHANGE_US_SYSTEM})).toEqual('One Hundred And Twenty Three Dollars');
+});
+
 test('million', () => {
     expect(atw.convertInWord(1921000, CountryCodes.USA)).toEqual('One Million Nine Hundred Twenty One Thousand Dollars');
 });
 test('billion', () => {
     expect(atw.convertInWord(554272561010, CountryCodes.USA)).toEqual('Five Hundred Fifty Four Billion Two Hundred Seventy Two Million Five Hundred Sixty One Thousand Ten Dollars');
+
+    expect(atw.convertInWord(554272561010, CountryCodes.USA, {implementation: FormatImplementation.USE_AND_IN_NO_CHANGE_US_SYSTEM})).toEqual('Five Hundred Fifty Four Billion Two Hundred Seventy Two Million Five Hundred Sixty One Thousand And Ten Dollars');
 });
 test('trillion', () => {
     expect(atw.convertInWord('632,362,999,101,001', CountryCodes.GBR)).toEqual('Six Hundred Thirty Two Trillion Three Hundred Sixty Two Billion Nine Hundred Ninety Nine Million One Hundred One Thousand One Pounds');
+
+    expect(atw.convertInWord('632,362,999,101,001', CountryCodes.GBR, {implementation: FormatImplementation.USE_AND_IN_NO_CHANGE_US_SYSTEM})).toEqual('Six Hundred Thirty Two Trillion Three Hundred Sixty Two Billion Nine Hundred Ninety Nine Million One Hundred One Thousand And One Pounds');
 });
 test('cent', () => {
     expect(atw.convertInWord('0.01', CountryCodes.USA)).toEqual('Zero Dollar And One Cent');
+    expect(atw.convertInWord('0.01', CountryCodes.USA, {implementation: FormatImplementation.USE_AND_IN_NO_CHANGE_US_SYSTEM})).toEqual('Zero Dollar And One Cent');
 });
 test('cents', () => {
     expect(atw.convertInWord('001.87', CountryCodes.USA)).toEqual('One Dollar And Eighty Seven Cents');


### PR DESCRIPTION
Created a format options with 'implementation' attribute to customize implementation used
Added options argument to #convertInWord
Added implementation and trailing part arguments to #convertInUs
Modified formatting using usNumSys to append 'and ...' for last segment when there is no 'change'.